### PR TITLE
コマンド送信者の権限が不足な際、エラーメッセージを表示せずにメンションを無効化する

### DIFF
--- a/dist/bot/responders/poll.js
+++ b/dist/bot/responders/poll.js
@@ -13,202 +13,11 @@ const error_1 = __importDefault(require("./error"));
 const help_1 = require("./help");
 var Poll;
 (function (Poll) {
-    const pollPermissions = [
-        'ADD_REACTIONS', 'READ_MESSAGE_HISTORY'
-    ];
-    const exclusivePermissions = [
-        'MANAGE_MESSAGES'
-    ];
-    const externalPermissions = [
-        'USE_EXTERNAL_EMOJIS'
-    ];
-    const mentionPermissions = [
-        'MENTION_EVERYONE'
-    ];
-    const attachImagePermissions = [
-        'ATTACH_FILES'
-    ];
-    function sumRequireAuthoerPermissions(query, permissions) {
-        return query.mentions.length && permissions.has(mentionPermissions)
-            ? mentionPermissions : [];
+    function initialize() {
+        allocater_1.Allocater.entryResponder(`${constants_1.COMMAND_PREFIX}poll`, chunk => respond(chunk, false));
+        allocater_1.Allocater.entryResponder(`${constants_1.COMMAND_PREFIX}expoll`, chunk => respond(chunk, true));
     }
-    function sumRequireMyPermissions(query) {
-        const permissions = pollPermissions.slice();
-        if (query.exclusive)
-            permissions.push(...exclusivePermissions);
-        if (query.choices.some(choice => choice.external))
-            permissions.push(...externalPermissions);
-        if (query.imageURL)
-            permissions.push(...attachImagePermissions);
-        return permissions;
-    }
-    function validateAuthorPermissions(chunk, query, myPermissions, authorPermissions) {
-        const requirePermissions = sumRequireAuthoerPermissions(query, myPermissions);
-        const missingPermissions = authorPermissions.missing(requirePermissions);
-        if (missingPermissions.length)
-            throw new error_1.default('lackYourPermissions', chunk.lang, missingPermissions);
-    }
-    function validateMyPermissions(chunk, query, permissions) {
-        const requirePermissions = sumRequireMyPermissions(query);
-        const missingPermissions = permissions.missing(requirePermissions);
-        if (missingPermissions.length)
-            throw new error_1.default('lackPermissions', chunk.lang, missingPermissions);
-    }
-    function getAuthorPermissionsFor(request) {
-        if (request.channel.type === 'dm')
-            return null;
-        if (request.webhookID)
-            return new discord_js_1.Permissions(constants_1.POSTULATE_WEBHOOK_PERMISSIONS);
-        else
-            return request.channel.permissionsFor(request.author);
-    }
-    function validatePermissions(chunk, query) {
-        const request = chunk.request;
-        const channel = request.channel;
-        if (channel.type === 'dm')
-            return false;
-        const myPermissions = channel.permissionsFor(chunk.botID);
-        const authorPermissions = getAuthorPermissionsFor(request);
-        if (!myPermissions || !authorPermissions)
-            return false;
-        validateMyPermissions(chunk, query, myPermissions);
-        validateAuthorPermissions(chunk, query, myPermissions, authorPermissions);
-        return true;
-    }
-    function isLocalGuildEmoji(guild, emoji) {
-        const match = emoji.match(/^<a?:.+?:(\d+)>$/);
-        return guild && match ? guild.emojis.cache.has(match[1]) : false;
-    }
-    const defaultEmojis = [
-        '🇦', '🇧', '🇨', '🇩', '🇪', '🇫', '🇬', '🇭', '🇮', '🇯', '🇰', '🇱', '🇲',
-        '🇳', '🇴', '🇵', '🇶', '🇷', '🇸', '🇹', '🇺', '🇻', '🇼', '🇽', '🇾', '🇿',
-    ];
-    const twemojiRegex = require('twemoji-parser/dist/lib/regex.js').default;
-    const emojiRegex = new RegExp(`^(${twemojiRegex.toString().slice(1, -2)}|<a?:.+?:\\d+>)$`);
-    function safePushChoiceEmoji(chunk, emojis, newEmoji) {
-        if (emojis.includes(newEmoji))
-            throw new error_1.default('duplicateEmojis', chunk.lang);
-        return emojis.push(newEmoji);
-    }
-    function safePushChoiceText(chunk, texts, newtext) {
-        if (newtext && newtext.length > constants_1.COMMAND_QUESTION_MAX)
-            throw new error_1.default('tooLongQuestion', chunk.lang);
-        return texts.push(newtext);
-    }
-    function generateChoices(chunk) {
-        const emojis = [], texts = [];
-        let external = false;
-        chunk.args.forEach(arg => {
-            if (emojiRegex.test(arg)) {
-                const length = safePushChoiceEmoji(chunk, emojis, arg);
-                if (texts.length < length - 1)
-                    safePushChoiceText(chunk, texts, null);
-                external || (external = !isLocalGuildEmoji(chunk.request.guild, arg));
-            }
-            else {
-                const length = safePushChoiceText(chunk, texts, arg);
-                if (emojis.length < length)
-                    safePushChoiceEmoji(chunk, emojis, defaultEmojis[length - 1]);
-            }
-        });
-        return emojis.map((emoji, i) => ({ emoji, text: texts[i], external }));
-    }
-    const twoChoiceEmojis = ['⭕', '❌'];
-    function generateTwoChoices() {
-        return twoChoiceEmojis.map(emoji => ({ emoji: emoji, text: null, external: false }));
-    }
-    function parseChoices(chunk) {
-        const choices = chunk.args.length ? generateChoices(chunk) : generateTwoChoices();
-        if (choices.length > constants_1.COMMAND_MAX_CHOICES)
-            throw new error_1.default('tooManyOptions', chunk.lang);
-        return choices;
-    }
-    function parseQuestion(chunk) {
-        return chunk.args.shift() ?? null;
-    }
-    function parseMentions(chunk) {
-        const mentions = [];
-        for (const arg of chunk.args) {
-            const matchMention = arg.match(/^(@everyone|@here|<@&\d+>)$/);
-            const matchEvery = arg.match(/^(?!\\)(everyone|here)$/);
-            const matchNumber = arg.match(/^(?!\\)(\d+)$/);
-            if (!matchMention && !matchEvery && !matchNumber)
-                break;
-            if (matchMention)
-                mentions.push(matchMention[1]);
-            if (matchEvery)
-                mentions.push(`@${matchEvery[1]}`);
-            if (matchNumber)
-                mentions.push(`<@&${matchNumber[1]}>`);
-        }
-        mentions.forEach(() => chunk.args.shift());
-        return mentions;
-    }
-    const imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
-    function parseAttachedImage(chunk) {
-        return chunk.request.attachments.find(attachment => imageExtensions.includes(path_1.extname(attachment.url)))?.url ?? null;
-    }
-    function parseAuthor(chunk) {
-        const user = chunk.request.author;
-        const member = chunk.request.member;
-        return {
-            iconURL: user.displayAvatarURL(),
-            name: member?.displayName ?? user.username,
-        };
-    }
-    function parse(chunk, exclusive) {
-        const query = {
-            exclusive: exclusive,
-            author: parseAuthor(chunk),
-            imageURL: parseAttachedImage(chunk),
-            mentions: parseMentions(chunk),
-            question: parseQuestion(chunk),
-            choices: parseChoices(chunk),
-        };
-        if (query.mentions.length && query.question === null)
-            throw new error_1.default('ungivenQuestion', chunk.lang);
-        return query;
-    }
-    function respondError(chunk, error) {
-        const options = { embed: error.embed };
-        const channel = chunk.request.channel;
-        const response = chunk.response;
-        return response ? response.edit(options) : channel.send(options);
-    }
-    function respondPoll(chunk, query, response) {
-        const choices = query.choices;
-        const selectors = choices.some(choice => choice.text !== null)
-            ? choices.map(choice => choice.emoji) : [];
-        return response.edit(query.mentions.join(' '), {
-            embed: locale_1.Locales[chunk.lang].successes.poll(query.exclusive, query.author.iconURL, query.author.name, query.question ?? '', selectors, choices.map(choice => choice.text ?? ''), query.imageURL ? path_1.basename(query.imageURL) : null, response.channel.id, response.id)
-        });
-    }
-    async function attachSelectors(chunk, query, response) {
-        try {
-            await Promise.all(query.choices.map(choice => response.react(choice.emoji)));
-        }
-        catch (exception) {
-            if (exception instanceof discord_js_1.DiscordAPIError)
-                if (exception.httpStatus === 400)
-                    throw new error_1.default('unusableEmoji', chunk.lang);
-        }
-    }
-    function respondLoading(chunk, query) {
-        return chunk.request.channel.send(query.mentions.join(' '), {
-            embed: locale_1.Locales[chunk.lang].loadings.poll(query.exclusive),
-            files: query.imageURL ? [query.imageURL] : [],
-        });
-    }
-    function respondHelp(chunk) {
-        const options = { content: '', embed: help_1.Help.getEmbed(chunk.lang) };
-        const channel = chunk.request.channel;
-        const response = chunk.response;
-        return response ? response.edit(options) : channel.send(options);
-    }
-    function clearSelectors(response) {
-        response.reactions.removeAll()
-            .catch(() => undefined);
-    }
+    Poll.initialize = initialize;
     async function respond(chunk, exclusive) {
         if (chunk.response)
             clearSelectors(chunk.response);
@@ -228,10 +37,201 @@ var Poll;
             throw error;
         }
     }
-    function initialize() {
-        allocater_1.Allocater.entryResponder(`${constants_1.COMMAND_PREFIX}poll`, chunk => respond(chunk, false));
-        allocater_1.Allocater.entryResponder(`${constants_1.COMMAND_PREFIX}expoll`, chunk => respond(chunk, true));
+    function clearSelectors(response) {
+        response.reactions.removeAll()
+            .catch(() => undefined);
     }
-    Poll.initialize = initialize;
+    function respondHelp(chunk) {
+        const options = { content: '', embed: help_1.Help.getEmbed(chunk.lang) };
+        const channel = chunk.request.channel;
+        const response = chunk.response;
+        return response ? response.edit(options) : channel.send(options);
+    }
+    function parse(chunk, exclusive) {
+        const query = {
+            exclusive: exclusive,
+            author: parseAuthor(chunk),
+            imageURL: parseAttachedImage(chunk),
+            mentions: parseMentions(chunk),
+            question: parseQuestion(chunk),
+            choices: parseChoices(chunk),
+        };
+        if (query.mentions.length && query.question === null)
+            throw new error_1.default('ungivenQuestion', chunk.lang);
+        return query;
+    }
+    function parseAuthor(chunk) {
+        const user = chunk.request.author;
+        const member = chunk.request.member;
+        return {
+            iconURL: user.displayAvatarURL(),
+            name: member?.displayName ?? user.username,
+        };
+    }
+    const imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
+    function parseAttachedImage(chunk) {
+        return chunk.request.attachments.find(attachment => imageExtensions.includes(path_1.extname(attachment.url)))?.url ?? null;
+    }
+    function parseMentions(chunk) {
+        const mentions = [];
+        for (const arg of chunk.args) {
+            const matchMention = arg.match(/^(@everyone|@here|<@&\d+>)$/);
+            const matchEvery = arg.match(/^(?!\\)(everyone|here)$/);
+            const matchNumber = arg.match(/^(?!\\)(\d+)$/);
+            if (!matchMention && !matchEvery && !matchNumber)
+                break;
+            if (matchMention)
+                mentions.push(matchMention[1]);
+            if (matchEvery)
+                mentions.push(`@${matchEvery[1]}`);
+            if (matchNumber)
+                mentions.push(`<@&${matchNumber[1]}>`);
+        }
+        mentions.forEach(() => chunk.args.shift());
+        return mentions;
+    }
+    function parseQuestion(chunk) {
+        return chunk.args.shift() ?? null;
+    }
+    function parseChoices(chunk) {
+        const choices = chunk.args.length ? generateChoices(chunk) : generateTwoChoices();
+        if (choices.length > constants_1.COMMAND_MAX_CHOICES)
+            throw new error_1.default('tooManyOptions', chunk.lang);
+        return choices;
+    }
+    const defaultEmojis = [
+        '🇦', '🇧', '🇨', '🇩', '🇪', '🇫', '🇬', '🇭', '🇮', '🇯', '🇰', '🇱', '🇲',
+        '🇳', '🇴', '🇵', '🇶', '🇷', '🇸', '🇹', '🇺', '🇻', '🇼', '🇽', '🇾', '🇿',
+    ];
+    const twemojiRegex = require('twemoji-parser/dist/lib/regex.js').default;
+    const emojiRegex = new RegExp(`^(${twemojiRegex.toString().slice(1, -2)}|<a?:.+?:\\d+>)$`);
+    function generateChoices(chunk) {
+        const emojis = [], texts = [];
+        let external = false;
+        chunk.args.forEach(arg => {
+            if (emojiRegex.test(arg)) {
+                const length = safePushChoiceEmoji(chunk, emojis, arg);
+                if (texts.length < length - 1)
+                    safePushChoiceText(chunk, texts, null);
+                external || (external = !isLocalGuildEmoji(chunk.request.guild, arg));
+            }
+            else {
+                const length = safePushChoiceText(chunk, texts, arg);
+                if (emojis.length < length)
+                    safePushChoiceEmoji(chunk, emojis, defaultEmojis[length - 1]);
+            }
+        });
+        return emojis.map((emoji, i) => ({ emoji, text: texts[i], external }));
+    }
+    function safePushChoiceEmoji(chunk, emojis, newEmoji) {
+        if (emojis.includes(newEmoji))
+            throw new error_1.default('duplicateEmojis', chunk.lang);
+        return emojis.push(newEmoji);
+    }
+    function safePushChoiceText(chunk, texts, newtext) {
+        if (newtext && newtext.length > constants_1.COMMAND_QUESTION_MAX)
+            throw new error_1.default('tooLongQuestion', chunk.lang);
+        return texts.push(newtext);
+    }
+    function isLocalGuildEmoji(guild, emoji) {
+        const match = emoji.match(/^<a?:.+?:(\d+)>$/);
+        return guild && match ? guild.emojis.cache.has(match[1]) : false;
+    }
+    const twoChoiceEmojis = ['⭕', '❌'];
+    function generateTwoChoices() {
+        return twoChoiceEmojis.map(emoji => ({ emoji: emoji, text: null, external: false }));
+    }
+    function validatePermissions(chunk, query) {
+        const request = chunk.request;
+        const channel = request.channel;
+        if (channel.type === 'dm')
+            return false;
+        const myPermissions = channel.permissionsFor(chunk.botID);
+        const authorPermissions = getAuthorPermissionsFor(request);
+        if (!myPermissions || !authorPermissions)
+            return false;
+        validateMyPermissions(chunk, query, myPermissions);
+        validateAuthorPermissions(chunk, query, myPermissions, authorPermissions);
+        return true;
+    }
+    const pollPermissions = [
+        'ADD_REACTIONS', 'READ_MESSAGE_HISTORY'
+    ];
+    const exclusivePermissions = [
+        'MANAGE_MESSAGES'
+    ];
+    const externalPermissions = [
+        'USE_EXTERNAL_EMOJIS'
+    ];
+    const mentionPermissions = [
+        'MENTION_EVERYONE'
+    ];
+    const attachImagePermissions = [
+        'ATTACH_FILES'
+    ];
+    function getAuthorPermissionsFor(request) {
+        if (request.channel.type === 'dm')
+            return null;
+        if (request.webhookID)
+            return new discord_js_1.Permissions(constants_1.POSTULATE_WEBHOOK_PERMISSIONS);
+        else
+            return request.channel.permissionsFor(request.author);
+    }
+    function validateMyPermissions(chunk, query, permissions) {
+        const requirePermissions = sumRequireMyPermissions(query);
+        const missingPermissions = permissions.missing(requirePermissions);
+        if (missingPermissions.length)
+            throw new error_1.default('lackPermissions', chunk.lang, missingPermissions);
+    }
+    function sumRequireMyPermissions(query) {
+        const permissions = pollPermissions.slice();
+        if (query.exclusive)
+            permissions.push(...exclusivePermissions);
+        if (query.choices.some(choice => choice.external))
+            permissions.push(...externalPermissions);
+        if (query.imageURL)
+            permissions.push(...attachImagePermissions);
+        return permissions;
+    }
+    function validateAuthorPermissions(chunk, query, myPermissions, authorPermissions) {
+        const requirePermissions = sumRequireAuthoerPermissions(query, myPermissions);
+        const missingPermissions = authorPermissions.missing(requirePermissions);
+        if (missingPermissions.length)
+            throw new error_1.default('lackYourPermissions', chunk.lang, missingPermissions);
+    }
+    function sumRequireAuthoerPermissions(query, permissions) {
+        return query.mentions.length && permissions.has(mentionPermissions)
+            ? mentionPermissions : [];
+    }
+    function respondLoading(chunk, query) {
+        return chunk.request.channel.send(query.mentions.join(' '), {
+            embed: locale_1.Locales[chunk.lang].loadings.poll(query.exclusive),
+            files: query.imageURL ? [query.imageURL] : [],
+        });
+    }
+    async function attachSelectors(chunk, query, response) {
+        try {
+            await Promise.all(query.choices.map(choice => response.react(choice.emoji)));
+        }
+        catch (exception) {
+            if (exception instanceof discord_js_1.DiscordAPIError)
+                if (exception.httpStatus === 400)
+                    throw new error_1.default('unusableEmoji', chunk.lang);
+        }
+    }
+    function respondPoll(chunk, query, response) {
+        const choices = query.choices;
+        const selectors = choices.some(choice => choice.text !== null)
+            ? choices.map(choice => choice.emoji) : [];
+        return response.edit(query.mentions.join(' '), {
+            embed: locale_1.Locales[chunk.lang].successes.poll(query.exclusive, query.author.iconURL, query.author.name, query.question ?? '', selectors, choices.map(choice => choice.text ?? ''), query.imageURL ? path_1.basename(query.imageURL) : null, response.channel.id, response.id)
+        });
+    }
+    function respondError(chunk, error) {
+        const options = { embed: error.embed };
+        const channel = chunk.request.channel;
+        const response = chunk.response;
+        return response ? response.edit(options) : channel.send(options);
+    }
 })(Poll = exports.Poll || (exports.Poll = {}));
-//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicG9sbC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uLy4uLy4uL3NyYy9ib3QvcmVzcG9uZGVycy9wb2xsLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7OztBQUFBLCtCQUF5QztBQUN6QywyQ0FNb0I7QUFFcEIsK0NBS3lCO0FBQ3pCLGdEQUE4QztBQUM5QyxzREFBaUU7QUFDakUsb0RBQW1DO0FBQ25DLGlDQUE4QjtBQUU5QixJQUFpQixJQUFJLENBeVVwQjtBQXpVRCxXQUFpQixJQUFJO0lBYW5CLE1BQU0sZUFBZSxHQUFnQztRQUNuRCxlQUFlLEVBQUUsc0JBQXNCO0tBQ3hDLENBQUM7SUFDRixNQUFNLG9CQUFvQixHQUFnQztRQUN4RCxpQkFBaUI7S0FDbEIsQ0FBQztJQUNGLE1BQU0sbUJBQW1CLEdBQWdDO1FBQ3ZELHFCQUFxQjtLQUN0QixDQUFDO0lBQ0YsTUFBTSxrQkFBa0IsR0FBZ0M7UUFDdEQsa0JBQWtCO0tBQ25CLENBQUM7SUFDRixNQUFNLHNCQUFzQixHQUFnQztRQUMxRCxjQUFjO0tBQ2YsQ0FBQztJQUVGLFNBQVMsNEJBQTRCLENBQ25DLEtBQVksRUFBRSxXQUFrQztRQUVoRCxPQUFPLEtBQUssQ0FBQyxRQUFRLENBQUMsTUFBTSxJQUFJLFdBQVcsQ0FBQyxHQUFHLENBQUMsa0JBQWtCLENBQUM7WUFDakUsQ0FBQyxDQUFDLGtCQUFrQixDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUM7SUFDOUIsQ0FBQztJQUVELFNBQVMsdUJBQXVCLENBQUMsS0FBWTtRQUMzQyxNQUFNLFdBQVcsR0FBRyxlQUFlLENBQUMsS0FBSyxFQUFFLENBQUM7UUFFNUMsSUFBSSxLQUFLLENBQUMsU0FBUztZQUFFLFdBQVcsQ0FBQyxJQUFJLENBQUMsR0FBRyxvQkFBb0IsQ0FBQyxDQUFDO1FBQy9ELElBQUksS0FBSyxDQUFDLE9BQU8sQ0FBQyxJQUFJLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQyxNQUFNLENBQUMsUUFBUSxDQUFDO1lBQy9DLFdBQVcsQ0FBQyxJQUFJLENBQUMsR0FBRyxtQkFBbUIsQ0FBQyxDQUFDO1FBQzNDLElBQUksS0FBSyxDQUFDLFFBQVE7WUFBRSxXQUFXLENBQUMsSUFBSSxDQUFDLEdBQUcsc0JBQXNCLENBQUMsQ0FBQztRQUVoRSxPQUFPLFdBQVcsQ0FBQztJQUNyQixDQUFDO0lBRUQsU0FBUyx5QkFBeUIsQ0FDaEMsS0FBbUIsRUFBRSxLQUFZLEVBQ2pDLGFBQW9DLEVBQ3BDLGlCQUF3QztRQUV4QyxNQUFNLGtCQUFrQixHQUNwQiw0QkFBNEIsQ0FBQyxLQUFLLEVBQUUsYUFBYSxDQUFDLENBQUM7UUFDdkQsTUFBTSxrQkFBa0IsR0FBRyxpQkFBaUIsQ0FBQyxPQUFPLENBQUMsa0JBQWtCLENBQUMsQ0FBQztRQUN6RSxJQUFJLGtCQUFrQixDQUFDLE1BQU07WUFDM0IsTUFBTSxJQUFJLGVBQVksQ0FDcEIscUJBQXFCLEVBQUUsS0FBSyxDQUFDLElBQUksRUFBRSxrQkFBa0IsQ0FDdEQsQ0FBQztJQUNOLENBQUM7SUFFRCxTQUFTLHFCQUFxQixDQUM1QixLQUFtQixFQUFFLEtBQVksRUFBRSxXQUFrQztRQUVyRSxNQUFNLGtCQUFrQixHQUFHLHVCQUF1QixDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQzFELE1BQU0sa0JBQWtCLEdBQUcsV0FBVyxDQUFDLE9BQU8sQ0FBQyxrQkFBa0IsQ0FBQyxDQUFDO1FBQ25FLElBQUksa0JBQWtCLENBQUMsTUFBTTtZQUMzQixNQUFNLElBQUksZUFBWSxDQUNwQixpQkFBaUIsRUFBRSxLQUFLLENBQUMsSUFBSSxFQUFFLGtCQUFrQixDQUNsRCxDQUFDO0lBQ04sQ0FBQztJQUVELFNBQVMsdUJBQXVCLENBQzlCLE9BQWdCO1FBRWhCLElBQUksT0FBTyxDQUFDLE9BQU8sQ0FBQyxJQUFJLEtBQUssSUFBSTtZQUFFLE9BQU8sSUFBSSxDQUFDO1FBRS9DLElBQUksT0FBTyxDQUFDLFNBQVM7WUFDbkIsT0FBTyxJQUFJLHdCQUFXLENBQUMseUNBQTZCLENBQUMsQ0FBQzs7WUFFdEQsT0FBTyxPQUFPLENBQUMsT0FBTyxDQUFDLGNBQWMsQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDLENBQUM7SUFDMUQsQ0FBQztJQUVELFNBQVMsbUJBQW1CLENBQzFCLEtBQW1CLEVBQUUsS0FBWTtRQUVqQyxNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsT0FBTyxDQUFDO1FBQzlCLE1BQU0sT0FBTyxHQUFHLE9BQU8sQ0FBQyxPQUFPLENBQUM7UUFDaEMsSUFBSSxPQUFPLENBQUMsSUFBSSxLQUFLLElBQUk7WUFBRSxPQUFPLEtBQUssQ0FBQztRQUV4QyxNQUFNLGFBQWEsR0FBRyxPQUFPLENBQUMsY0FBYyxDQUFDLEtBQUssQ0FBQyxLQUFLLENBQUMsQ0FBQztRQUMxRCxNQUFNLGlCQUFpQixHQUFHLHVCQUF1QixDQUFDLE9BQU8sQ0FBQyxDQUFDO1FBQzNELElBQUksQ0FBQyxhQUFhLElBQUksQ0FBQyxpQkFBaUI7WUFBRSxPQUFPLEtBQUssQ0FBQztRQUV2RCxxQkFBcUIsQ0FBQyxLQUFLLEVBQUUsS0FBSyxFQUFFLGFBQWEsQ0FBQyxDQUFDO1FBQ25ELHlCQUF5QixDQUFDLEtBQUssRUFBRSxLQUFLLEVBQUUsYUFBYSxFQUFFLGlCQUFpQixDQUFDLENBQUM7UUFFMUUsT0FBTyxJQUFJLENBQUM7SUFDZCxDQUFDO0lBRUQsU0FBUyxpQkFBaUIsQ0FBQyxLQUFtQixFQUFFLEtBQWE7UUFDM0QsTUFBTSxLQUFLLEdBQUcsS0FBSyxDQUFDLEtBQUssQ0FBQyxrQkFBa0IsQ0FBQyxDQUFDO1FBQzlDLE9BQU8sS0FBSyxJQUFJLEtBQUssQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUM7SUFDbkUsQ0FBQztJQUVELE1BQU0sYUFBYSxHQUFHO1FBQ3BCLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUk7UUFDNUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSTtLQUM3RSxDQUFDO0lBQ0YsTUFBTSxZQUFZLEdBQ2QsT0FBTyxDQUFDLGtDQUFrQyxDQUFDLENBQUMsT0FBaUIsQ0FBQztJQUNsRSxNQUFNLFVBQVUsR0FDWixJQUFJLE1BQU0sQ0FBQyxLQUFLLFlBQVksQ0FBQyxRQUFRLEVBQUUsQ0FBQyxLQUFLLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQyxDQUFDLGtCQUFrQixDQUFDLENBQUM7SUFFNUUsU0FBUyxtQkFBbUIsQ0FDMUIsS0FBbUIsRUFBRSxNQUFnQixFQUFFLFFBQWdCO1FBRXZELElBQUksTUFBTSxDQUFDLFFBQVEsQ0FBQyxRQUFRLENBQUM7WUFDM0IsTUFBTSxJQUFJLGVBQVksQ0FBQyxpQkFBaUIsRUFBRSxLQUFLLENBQUMsSUFBSSxDQUFDLENBQUM7UUFFeEQsT0FBTyxNQUFNLENBQUMsSUFBSSxDQUFDLFFBQVEsQ0FBQyxDQUFDO0lBQy9CLENBQUM7SUFFRCxTQUFTLGtCQUFrQixDQUN6QixLQUFtQixFQUFFLEtBQXdCLEVBQUUsT0FBc0I7UUFFckUsSUFBSSxPQUFPLElBQUksT0FBTyxDQUFDLE1BQU0sR0FBRyxnQ0FBb0I7WUFDbEQsTUFBTSxJQUFJLGVBQVksQ0FBQyxpQkFBaUIsRUFBRSxLQUFLLENBQUMsSUFBSSxDQUFDLENBQUM7UUFFeEQsT0FBTyxLQUFLLENBQUMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxDQUFDO0lBQzdCLENBQUM7SUFFRCxTQUFTLGVBQWUsQ0FBQyxLQUFtQjtRQUMxQyxNQUFNLE1BQU0sR0FBYSxFQUFFLEVBQUUsS0FBSyxHQUFzQixFQUFFLENBQUM7UUFDM0QsSUFBSSxRQUFRLEdBQUcsS0FBSyxDQUFDO1FBRXJCLEtBQUssQ0FBQyxJQUFJLENBQUMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxFQUFFO1lBQ3ZCLElBQUksVUFBVSxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFBRTtnQkFDeEIsTUFBTSxNQUFNLEdBQUcsbUJBQW1CLENBQUMsS0FBSyxFQUFFLE1BQU0sRUFBRSxHQUFHLENBQUMsQ0FBQztnQkFDdkQsSUFBSSxLQUFLLENBQUMsTUFBTSxHQUFHLE1BQU0sR0FBRyxDQUFDO29CQUFFLGtCQUFrQixDQUFDLEtBQUssRUFBRSxLQUFLLEVBQUUsSUFBSSxDQUFDLENBQUM7Z0JBRXRFLFFBQVEsS0FBUixRQUFRLEdBQUssQ0FBQyxpQkFBaUIsQ0FBQyxLQUFLLENBQUMsT0FBTyxDQUFDLEtBQUssRUFBRSxHQUFHLENBQUMsRUFBQzthQUMzRDtpQkFDSTtnQkFDSCxNQUFNLE1BQU0sR0FBRyxrQkFBa0IsQ0FBQyxLQUFLLEVBQUUsS0FBSyxFQUFFLEdBQUcsQ0FBQyxDQUFDO2dCQUNyRCxJQUFJLE1BQU0sQ0FBQyxNQUFNLEdBQUcsTUFBTTtvQkFDeEIsbUJBQW1CLENBQUMsS0FBSyxFQUFFLE1BQU0sRUFBRSxhQUFhLENBQUMsTUFBTSxHQUFHLENBQUMsQ0FBQyxDQUFDLENBQUM7YUFDakU7UUFDSCxDQUFDLENBQUMsQ0FBQztRQUVILE9BQU8sTUFBTSxDQUFDLEdBQUcsQ0FBQyxDQUFDLEtBQUssRUFBRSxDQUFDLEVBQUUsRUFBRSxDQUFDLENBQUMsRUFBRSxLQUFLLEVBQUUsSUFBSSxFQUFFLEtBQUssQ0FBQyxDQUFDLENBQUMsRUFBRSxRQUFRLEVBQUUsQ0FBQyxDQUFDLENBQUM7SUFDekUsQ0FBQztJQUVELE1BQU0sZUFBZSxHQUFHLENBQUMsR0FBRyxFQUFFLEdBQUcsQ0FBQyxDQUFDO0lBRW5DLFNBQVMsa0JBQWtCO1FBQ3pCLE9BQU8sZUFBZSxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsRUFBRSxDQUFDLENBQ2xDLEVBQUUsS0FBSyxFQUFFLEtBQUssRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLFFBQVEsRUFBRSxLQUFLLEVBQUUsQ0FDOUMsQ0FBQyxDQUFDO0lBQ0wsQ0FBQztJQUVELFNBQVMsWUFBWSxDQUFDLEtBQW1CO1FBQ3ZDLE1BQU0sT0FBTyxHQUNULEtBQUssQ0FBQyxJQUFJLENBQUMsTUFBTSxDQUFDLENBQUMsQ0FBQyxlQUFlLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLGtCQUFrQixFQUFFLENBQUM7UUFFdEUsSUFBSSxPQUFPLENBQUMsTUFBTSxHQUFHLCtCQUFtQjtZQUN0QyxNQUFNLElBQUksZUFBWSxDQUFDLGdCQUFnQixFQUFFLEtBQUssQ0FBQyxJQUFJLENBQUMsQ0FBQztRQUV2RCxPQUFPLE9BQU8sQ0FBQztJQUNqQixDQUFDO0lBRUQsU0FBUyxhQUFhLENBQUMsS0FBbUI7UUFDeEMsT0FBTyxLQUFLLENBQUMsSUFBSSxDQUFDLEtBQUssRUFBRSxJQUFJLElBQUksQ0FBQztJQUNwQyxDQUFDO0lBRUQsU0FBUyxhQUFhLENBQUMsS0FBbUI7UUFDeEMsTUFBTSxRQUFRLEdBQWEsRUFBRSxDQUFDO1FBRTlCLEtBQUssTUFBTSxHQUFHLElBQUksS0FBSyxDQUFDLElBQUksRUFBRTtZQUM1QixNQUFNLFlBQVksR0FBRyxHQUFHLENBQUMsS0FBSyxDQUFDLDZCQUE2QixDQUFDLENBQUM7WUFDOUQsTUFBTSxVQUFVLEdBQUssR0FBRyxDQUFDLEtBQUssQ0FBQyx5QkFBeUIsQ0FBQyxDQUFDO1lBQzFELE1BQU0sV0FBVyxHQUFJLEdBQUcsQ0FBQyxLQUFLLENBQUMsZUFBZSxDQUFDLENBQUM7WUFDaEQsSUFBSSxDQUFDLFlBQVksSUFBSSxDQUFDLFVBQVUsSUFBSSxDQUFDLFdBQVc7Z0JBQUUsTUFBTTtZQUV4RCxJQUFJLFlBQVk7Z0JBQUUsUUFBUSxDQUFDLElBQUksQ0FBQyxZQUFZLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQztZQUNqRCxJQUFJLFVBQVU7Z0JBQUksUUFBUSxDQUFDLElBQUksQ0FBQyxJQUFJLFVBQVUsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUM7WUFDckQsSUFBSSxXQUFXO2dCQUFHLFFBQVEsQ0FBQyxJQUFJLENBQUMsTUFBTSxXQUFXLENBQUMsQ0FBQyxDQUFDLEdBQUcsQ0FBQyxDQUFDO1NBQzFEO1FBRUQsUUFBUSxDQUFDLE9BQU8sQ0FBQyxHQUFHLEVBQUUsQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLEtBQUssRUFBRSxDQUFDLENBQUM7UUFFM0MsT0FBTyxRQUFRLENBQUM7SUFDbEIsQ0FBQztJQUVELE1BQU0sZUFBZSxHQUFHLENBQUMsTUFBTSxFQUFFLE1BQU0sRUFBRSxPQUFPLEVBQUUsTUFBTSxFQUFFLE9BQU8sQ0FBQyxDQUFDO0lBRW5FLFNBQVMsa0JBQWtCLENBQUMsS0FBbUI7UUFDN0MsT0FBTyxLQUFLLENBQUMsT0FBTyxDQUFDLFdBQVcsQ0FBQyxJQUFJLENBQ25DLFVBQVUsQ0FBQyxFQUFFLENBQUMsZUFBZSxDQUFDLFFBQVEsQ0FBQyxjQUFPLENBQUMsVUFBVSxDQUFDLEdBQUcsQ0FBQyxDQUFDLENBQ2hFLEVBQUUsR0FBRyxJQUFJLElBQUksQ0FBQztJQUNqQixDQUFDO0lBRUQsU0FBUyxXQUFXLENBQUMsS0FBbUI7UUFDdEMsTUFBTSxJQUFJLEdBQUcsS0FBSyxDQUFDLE9BQU8sQ0FBQyxNQUFNLENBQUM7UUFDbEMsTUFBTSxNQUFNLEdBQUcsS0FBSyxDQUFDLE9BQU8sQ0FBQyxNQUFNLENBQUM7UUFFcEMsT0FBTztZQUNMLE9BQU8sRUFBRSxJQUFJLENBQUMsZ0JBQWdCLEVBQUU7WUFDaEMsSUFBSSxFQUFFLE1BQU0sRUFBRSxXQUFXLElBQUksSUFBSSxDQUFDLFFBQVE7U0FDM0MsQ0FBQztJQUNKLENBQUM7SUFFRCxTQUFTLEtBQUssQ0FBQyxLQUFtQixFQUFFLFNBQWtCO1FBQ3BELE1BQU0sS0FBSyxHQUFHO1lBQ1osU0FBUyxFQUFFLFNBQVM7WUFDcEIsTUFBTSxFQUFLLFdBQVcsQ0FBQyxLQUFLLENBQUM7WUFDN0IsUUFBUSxFQUFHLGtCQUFrQixDQUFDLEtBQUssQ0FBQztZQUNwQyxRQUFRLEVBQUcsYUFBYSxDQUFDLEtBQUssQ0FBQztZQUMvQixRQUFRLEVBQUcsYUFBYSxDQUFDLEtBQUssQ0FBQztZQUMvQixPQUFPLEVBQUksWUFBWSxDQUFDLEtBQUssQ0FBQztTQUMvQixDQUFDO1FBRUYsSUFBSSxLQUFLLENBQUMsUUFBUSxDQUFDLE1BQU0sSUFBSSxLQUFLLENBQUMsUUFBUSxLQUFLLElBQUk7WUFDbEQsTUFBTSxJQUFJLGVBQVksQ0FBQyxpQkFBaUIsRUFBRSxLQUFLLENBQUMsSUFBSSxDQUFDLENBQUM7UUFFeEQsT0FBTyxLQUFLLENBQUM7SUFDZixDQUFDO0lBRUQsU0FBUyxZQUFZLENBQ25CLEtBQW1CLEVBQUUsS0FBbUI7UUFFeEMsTUFBTSxPQUFPLEdBQUcsRUFBRSxLQUFLLEVBQUUsS0FBSyxDQUFDLEtBQUssRUFBRSxDQUFDO1FBQ3ZDLE1BQU0sT0FBTyxHQUFHLEtBQUssQ0FBQyxPQUFPLENBQUMsT0FBTyxDQUFDO1FBQ3RDLE1BQU0sUUFBUSxHQUFHLEtBQUssQ0FBQyxRQUFRLENBQUM7UUFFaEMsT0FBTyxRQUFRLENBQUMsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxJQUFJLENBQUMsT0FBTyxDQUFDLENBQUM7SUFDbkUsQ0FBQztJQUVELFNBQVMsV0FBVyxDQUNsQixLQUFtQixFQUFFLEtBQVksRUFBRSxRQUFpQjtRQUVwRCxNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsT0FBTyxDQUFDO1FBQzlCLE1BQU0sU0FBUyxHQUFhLE9BQU8sQ0FBQyxJQUFJLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQyxNQUFNLENBQUMsSUFBSSxLQUFLLElBQUksQ0FBQztZQUN0RSxDQUFDLENBQUMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBRTdDLE9BQU8sUUFBUSxDQUFDLElBQUksQ0FDbEIsS0FBSyxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQ3hCO1lBQ0UsS0FBSyxFQUFFLGdCQUFPLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDLFNBQVMsQ0FBQyxJQUFJLENBQ3ZDLEtBQUssQ0FBQyxTQUFTLEVBQ2YsS0FBSyxDQUFDLE1BQU0sQ0FBQyxPQUFPLEVBQ3BCLEtBQUssQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUNqQixLQUFLLENBQUMsUUFBUSxJQUFJLEVBQUUsRUFDcEIsU0FBUyxFQUNULE9BQU8sQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQyxNQUFNLENBQUMsSUFBSSxJQUFJLEVBQUUsQ0FBQyxFQUN4QyxLQUFLLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyxlQUFRLENBQUMsS0FBSyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLEVBQ2hELFFBQVEsQ0FBQyxPQUFPLENBQUMsRUFBRSxFQUNuQixRQUFRLENBQUMsRUFBRSxDQUNaO1NBQ0YsQ0FDRixDQUFDO0lBQ0osQ0FBQztJQUVELEtBQUssVUFBVSxlQUFlLENBQzVCLEtBQW1CLEVBQUUsS0FBWSxFQUFFLFFBQWlCO1FBRXBELElBQUk7WUFDRixNQUFNLE9BQU8sQ0FBQyxHQUFHLENBQ2YsS0FBSyxDQUFDLE9BQU8sQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQyxRQUFRLENBQUMsS0FBSyxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUMxRCxDQUFDO1NBQ0g7UUFDRCxPQUFPLFNBQWtCLEVBQUU7WUFDekIsSUFBSSxTQUFTLFlBQVksNEJBQWU7Z0JBQ3RDLElBQUksU0FBUyxDQUFDLFVBQVUsS0FBSyxHQUFHO29CQUM5QixNQUFNLElBQUksZUFBWSxDQUFDLGVBQWUsRUFBRSxLQUFLLENBQUMsSUFBSSxDQUFDLENBQUM7U0FDekQ7SUFDSCxDQUFDO0lBRUQsU0FBUyxjQUFjLENBQUMsS0FBbUIsRUFBRSxLQUFZO1FBQ3ZELE9BQU8sS0FBSyxDQUFDLE9BQU8sQ0FBQyxPQUFPLENBQUMsSUFBSSxDQUMvQixLQUFLLENBQUMsUUFBUSxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUMsRUFDeEI7WUFDRSxLQUFLLEVBQUUsZ0JBQU8sQ0FBQyxLQUFLLENBQUMsSUFBSSxDQUFDLENBQUMsUUFBUSxDQUFDLElBQUksQ0FBQyxLQUFLLENBQUMsU0FBUyxDQUFDO1lBQ3pELEtBQUssRUFBRSxLQUFLLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRTtTQUM5QyxDQUNGLENBQUM7SUFDSixDQUFDO0lBRUQsU0FBUyxXQUFXLENBQUMsS0FBbUI7UUFDdEMsTUFBTSxPQUFPLEdBQUcsRUFBRSxPQUFPLEVBQUUsRUFBRSxFQUFFLEtBQUssRUFBRSxXQUFJLENBQUMsUUFBUSxDQUFDLEtBQUssQ0FBQyxJQUFJLENBQUMsRUFBRSxDQUFDO1FBQ2xFLE1BQU0sT0FBTyxHQUFHLEtBQUssQ0FBQyxPQUFPLENBQUMsT0FBTyxDQUFDO1FBQ3RDLE1BQU0sUUFBUSxHQUFHLEtBQUssQ0FBQyxRQUFRLENBQUM7UUFFaEMsT0FBTyxRQUFRLENBQUMsQ0FBQyxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxDQUFDLE9BQU8sQ0FBQyxJQUFJLENBQUMsT0FBTyxDQUFDLENBQUM7SUFDbkUsQ0FBQztJQUVELFNBQVMsY0FBYyxDQUFDLFFBQWlCO1FBQ3ZDLFFBQVEsQ0FBQyxTQUFTLENBQUMsU0FBUyxFQUFFO2FBQzNCLEtBQUssQ0FBQyxHQUFHLEVBQUUsQ0FBQyxTQUFTLENBQUMsQ0FBQztJQUM1QixDQUFDO0lBRUQsS0FBSyxVQUFVLE9BQU8sQ0FDcEIsS0FBbUIsRUFBRSxTQUFrQjtRQUV2QyxJQUFJLEtBQUssQ0FBQyxRQUFRO1lBQUUsY0FBYyxDQUFDLEtBQUssQ0FBQyxRQUFRLENBQUMsQ0FBQztRQUNuRCxJQUFJLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxNQUFNO1lBQUUsT0FBTyxXQUFXLENBQUMsS0FBSyxDQUFDLENBQUM7UUFFbEQsSUFBSTtZQUNGLE1BQU0sS0FBSyxHQUFHLEtBQUssQ0FBQyxLQUFLLEVBQUUsU0FBUyxDQUFDLENBQUM7WUFDdEMsSUFBSSxDQUFDLG1CQUFtQixDQUFDLEtBQUssRUFBRSxLQUFLLENBQUM7Z0JBQUUsT0FBTyxJQUFJLENBQUM7WUFFcEQsS0FBSyxDQUFDLFFBQVEsS0FBZCxLQUFLLENBQUMsUUFBUSxHQUFLLE1BQU0sY0FBYyxDQUFDLEtBQUssRUFBRSxLQUFLLENBQUMsRUFBQztZQUN0RCxNQUFNLGVBQWUsQ0FBQyxLQUFLLEVBQUUsS0FBSyxFQUFFLEtBQUssQ0FBQyxRQUFRLENBQUMsQ0FBQztZQUNwRCxPQUFPLFdBQVcsQ0FBQyxLQUFLLEVBQUUsS0FBSyxFQUFFLEtBQUssQ0FBQyxRQUFRLENBQUMsQ0FBQztTQUNsRDtRQUNELE9BQU8sS0FBYyxFQUFFO1lBQ3JCLElBQUksS0FBSyxZQUFZLGVBQVk7Z0JBQUUsT0FBTyxZQUFZLENBQUMsS0FBSyxFQUFFLEtBQUssQ0FBQyxDQUFDO1lBQ3JFLE1BQU0sS0FBSyxDQUFDO1NBQ2I7SUFDSCxDQUFDO0lBRUQsU0FBZ0IsVUFBVTtRQUN4QixxQkFBUyxDQUFDLGNBQWMsQ0FDdEIsR0FBRywwQkFBYyxNQUFNLEVBQUksS0FBSyxDQUFDLEVBQUUsQ0FBQyxPQUFPLENBQUMsS0FBSyxFQUFFLEtBQUssQ0FBQyxDQUMxRCxDQUFDO1FBQ0YscUJBQVMsQ0FBQyxjQUFjLENBQ3RCLEdBQUcsMEJBQWMsUUFBUSxFQUFFLEtBQUssQ0FBQyxFQUFFLENBQUMsT0FBTyxDQUFDLEtBQUssRUFBRSxJQUFJLENBQUMsQ0FDekQsQ0FBQztJQUNKLENBQUM7SUFQZSxlQUFVLGFBT3pCLENBQUE7QUFDSCxDQUFDLEVBelVnQixJQUFJLEdBQUosWUFBSSxLQUFKLFlBQUksUUF5VXBCIn0=
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoicG9sbC5qcyIsInNvdXJjZVJvb3QiOiIiLCJzb3VyY2VzIjpbIi4uLy4uLy4uL3NyYy9ib3QvcmVzcG9uZGVycy9wb2xsLnRzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiI7Ozs7OztBQUFBLCtCQUF5QztBQUN6QywyQ0FNb0I7QUFFcEIsK0NBS3lCO0FBQ3pCLGdEQUE4QztBQUM5QyxzREFBaUU7QUFDakUsb0RBQW1DO0FBQ25DLGlDQUE4QjtBQUU5QixJQUFpQixJQUFJLENBeVVwQjtBQXpVRCxXQUFpQixJQUFJO0lBYW5CLFNBQWdCLFVBQVU7UUFDeEIscUJBQVMsQ0FBQyxjQUFjLENBQ3RCLEdBQUcsMEJBQWMsTUFBTSxFQUFJLEtBQUssQ0FBQyxFQUFFLENBQUMsT0FBTyxDQUFDLEtBQUssRUFBRSxLQUFLLENBQUMsQ0FDMUQsQ0FBQztRQUNGLHFCQUFTLENBQUMsY0FBYyxDQUN0QixHQUFHLDBCQUFjLFFBQVEsRUFBRSxLQUFLLENBQUMsRUFBRSxDQUFDLE9BQU8sQ0FBQyxLQUFLLEVBQUUsSUFBSSxDQUFDLENBQ3pELENBQUM7SUFDSixDQUFDO0lBUGUsZUFBVSxhQU96QixDQUFBO0lBRUQsS0FBSyxVQUFVLE9BQU8sQ0FDcEIsS0FBbUIsRUFBRSxTQUFrQjtRQUV2QyxJQUFJLEtBQUssQ0FBQyxRQUFRO1lBQUUsY0FBYyxDQUFDLEtBQUssQ0FBQyxRQUFRLENBQUMsQ0FBQztRQUNuRCxJQUFJLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxNQUFNO1lBQUUsT0FBTyxXQUFXLENBQUMsS0FBSyxDQUFDLENBQUM7UUFFbEQsSUFBSTtZQUNGLE1BQU0sS0FBSyxHQUFHLEtBQUssQ0FBQyxLQUFLLEVBQUUsU0FBUyxDQUFDLENBQUM7WUFDdEMsSUFBSSxDQUFDLG1CQUFtQixDQUFDLEtBQUssRUFBRSxLQUFLLENBQUM7Z0JBQUUsT0FBTyxJQUFJLENBQUM7WUFFcEQsS0FBSyxDQUFDLFFBQVEsS0FBZCxLQUFLLENBQUMsUUFBUSxHQUFLLE1BQU0sY0FBYyxDQUFDLEtBQUssRUFBRSxLQUFLLENBQUMsRUFBQztZQUN0RCxNQUFNLGVBQWUsQ0FBQyxLQUFLLEVBQUUsS0FBSyxFQUFFLEtBQUssQ0FBQyxRQUFRLENBQUMsQ0FBQztZQUNwRCxPQUFPLFdBQVcsQ0FBQyxLQUFLLEVBQUUsS0FBSyxFQUFFLEtBQUssQ0FBQyxRQUFRLENBQUMsQ0FBQztTQUNsRDtRQUNELE9BQU8sS0FBYyxFQUFFO1lBQ3JCLElBQUksS0FBSyxZQUFZLGVBQVk7Z0JBQUUsT0FBTyxZQUFZLENBQUMsS0FBSyxFQUFFLEtBQUssQ0FBQyxDQUFDO1lBQ3JFLE1BQU0sS0FBSyxDQUFDO1NBQ2I7SUFDSCxDQUFDO0lBRUQsU0FBUyxjQUFjLENBQUMsUUFBaUI7UUFDdkMsUUFBUSxDQUFDLFNBQVMsQ0FBQyxTQUFTLEVBQUU7YUFDM0IsS0FBSyxDQUFDLEdBQUcsRUFBRSxDQUFDLFNBQVMsQ0FBQyxDQUFDO0lBQzVCLENBQUM7SUFFRCxTQUFTLFdBQVcsQ0FBQyxLQUFtQjtRQUN0QyxNQUFNLE9BQU8sR0FBRyxFQUFFLE9BQU8sRUFBRSxFQUFFLEVBQUUsS0FBSyxFQUFFLFdBQUksQ0FBQyxRQUFRLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxFQUFFLENBQUM7UUFDbEUsTUFBTSxPQUFPLEdBQUcsS0FBSyxDQUFDLE9BQU8sQ0FBQyxPQUFPLENBQUM7UUFDdEMsTUFBTSxRQUFRLEdBQUcsS0FBSyxDQUFDLFFBQVEsQ0FBQztRQUVoQyxPQUFPLFFBQVEsQ0FBQyxDQUFDLENBQUMsUUFBUSxDQUFDLElBQUksQ0FBQyxPQUFPLENBQUMsQ0FBQyxDQUFDLENBQUMsT0FBTyxDQUFDLElBQUksQ0FBQyxPQUFPLENBQUMsQ0FBQztJQUNuRSxDQUFDO0lBRUQsU0FBUyxLQUFLLENBQUMsS0FBbUIsRUFBRSxTQUFrQjtRQUNwRCxNQUFNLEtBQUssR0FBRztZQUNaLFNBQVMsRUFBRSxTQUFTO1lBQ3BCLE1BQU0sRUFBSyxXQUFXLENBQUMsS0FBSyxDQUFDO1lBQzdCLFFBQVEsRUFBRyxrQkFBa0IsQ0FBQyxLQUFLLENBQUM7WUFDcEMsUUFBUSxFQUFHLGFBQWEsQ0FBQyxLQUFLLENBQUM7WUFDL0IsUUFBUSxFQUFHLGFBQWEsQ0FBQyxLQUFLLENBQUM7WUFDL0IsT0FBTyxFQUFJLFlBQVksQ0FBQyxLQUFLLENBQUM7U0FDL0IsQ0FBQztRQUVGLElBQUksS0FBSyxDQUFDLFFBQVEsQ0FBQyxNQUFNLElBQUksS0FBSyxDQUFDLFFBQVEsS0FBSyxJQUFJO1lBQ2xELE1BQU0sSUFBSSxlQUFZLENBQUMsaUJBQWlCLEVBQUUsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDO1FBRXhELE9BQU8sS0FBSyxDQUFDO0lBQ2YsQ0FBQztJQUVELFNBQVMsV0FBVyxDQUFDLEtBQW1CO1FBQ3RDLE1BQU0sSUFBSSxHQUFHLEtBQUssQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDO1FBQ2xDLE1BQU0sTUFBTSxHQUFHLEtBQUssQ0FBQyxPQUFPLENBQUMsTUFBTSxDQUFDO1FBRXBDLE9BQU87WUFDTCxPQUFPLEVBQUUsSUFBSSxDQUFDLGdCQUFnQixFQUFFO1lBQ2hDLElBQUksRUFBRSxNQUFNLEVBQUUsV0FBVyxJQUFJLElBQUksQ0FBQyxRQUFRO1NBQzNDLENBQUM7SUFDSixDQUFDO0lBRUQsTUFBTSxlQUFlLEdBQUcsQ0FBQyxNQUFNLEVBQUUsTUFBTSxFQUFFLE9BQU8sRUFBRSxNQUFNLEVBQUUsT0FBTyxDQUFDLENBQUM7SUFFbkUsU0FBUyxrQkFBa0IsQ0FBQyxLQUFtQjtRQUM3QyxPQUFPLEtBQUssQ0FBQyxPQUFPLENBQUMsV0FBVyxDQUFDLElBQUksQ0FDbkMsVUFBVSxDQUFDLEVBQUUsQ0FBQyxlQUFlLENBQUMsUUFBUSxDQUFDLGNBQU8sQ0FBQyxVQUFVLENBQUMsR0FBRyxDQUFDLENBQUMsQ0FDaEUsRUFBRSxHQUFHLElBQUksSUFBSSxDQUFDO0lBQ2pCLENBQUM7SUFFRCxTQUFTLGFBQWEsQ0FBQyxLQUFtQjtRQUN4QyxNQUFNLFFBQVEsR0FBYSxFQUFFLENBQUM7UUFFOUIsS0FBSyxNQUFNLEdBQUcsSUFBSSxLQUFLLENBQUMsSUFBSSxFQUFFO1lBQzVCLE1BQU0sWUFBWSxHQUFHLEdBQUcsQ0FBQyxLQUFLLENBQUMsNkJBQTZCLENBQUMsQ0FBQztZQUM5RCxNQUFNLFVBQVUsR0FBSyxHQUFHLENBQUMsS0FBSyxDQUFDLHlCQUF5QixDQUFDLENBQUM7WUFDMUQsTUFBTSxXQUFXLEdBQUksR0FBRyxDQUFDLEtBQUssQ0FBQyxlQUFlLENBQUMsQ0FBQztZQUNoRCxJQUFJLENBQUMsWUFBWSxJQUFJLENBQUMsVUFBVSxJQUFJLENBQUMsV0FBVztnQkFBRSxNQUFNO1lBRXhELElBQUksWUFBWTtnQkFBRSxRQUFRLENBQUMsSUFBSSxDQUFDLFlBQVksQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDO1lBQ2pELElBQUksVUFBVTtnQkFBSSxRQUFRLENBQUMsSUFBSSxDQUFDLElBQUksVUFBVSxDQUFDLENBQUMsQ0FBQyxFQUFFLENBQUMsQ0FBQztZQUNyRCxJQUFJLFdBQVc7Z0JBQUcsUUFBUSxDQUFDLElBQUksQ0FBQyxNQUFNLFdBQVcsQ0FBQyxDQUFDLENBQUMsR0FBRyxDQUFDLENBQUM7U0FDMUQ7UUFFRCxRQUFRLENBQUMsT0FBTyxDQUFDLEdBQUcsRUFBRSxDQUFDLEtBQUssQ0FBQyxJQUFJLENBQUMsS0FBSyxFQUFFLENBQUMsQ0FBQztRQUUzQyxPQUFPLFFBQVEsQ0FBQztJQUNsQixDQUFDO0lBRUQsU0FBUyxhQUFhLENBQUMsS0FBbUI7UUFDeEMsT0FBTyxLQUFLLENBQUMsSUFBSSxDQUFDLEtBQUssRUFBRSxJQUFJLElBQUksQ0FBQztJQUNwQyxDQUFDO0lBRUQsU0FBUyxZQUFZLENBQUMsS0FBbUI7UUFDdkMsTUFBTSxPQUFPLEdBQ1QsS0FBSyxDQUFDLElBQUksQ0FBQyxNQUFNLENBQUMsQ0FBQyxDQUFDLGVBQWUsQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUMsa0JBQWtCLEVBQUUsQ0FBQztRQUV0RSxJQUFJLE9BQU8sQ0FBQyxNQUFNLEdBQUcsK0JBQW1CO1lBQ3RDLE1BQU0sSUFBSSxlQUFZLENBQUMsZ0JBQWdCLEVBQUUsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDO1FBRXZELE9BQU8sT0FBTyxDQUFDO0lBQ2pCLENBQUM7SUFFRCxNQUFNLGFBQWEsR0FBRztRQUNwQixJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJO1FBQzVFLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsSUFBSSxFQUFFLElBQUk7S0FDN0UsQ0FBQztJQUNGLE1BQU0sWUFBWSxHQUNkLE9BQU8sQ0FBQyxrQ0FBa0MsQ0FBQyxDQUFDLE9BQWlCLENBQUM7SUFDbEUsTUFBTSxVQUFVLEdBQ1osSUFBSSxNQUFNLENBQUMsS0FBSyxZQUFZLENBQUMsUUFBUSxFQUFFLENBQUMsS0FBSyxDQUFDLENBQUMsRUFBRSxDQUFDLENBQUMsQ0FBQyxrQkFBa0IsQ0FBQyxDQUFDO0lBRTVFLFNBQVMsZUFBZSxDQUFDLEtBQW1CO1FBQzFDLE1BQU0sTUFBTSxHQUFhLEVBQUUsRUFBRSxLQUFLLEdBQXNCLEVBQUUsQ0FBQztRQUMzRCxJQUFJLFFBQVEsR0FBRyxLQUFLLENBQUM7UUFFckIsS0FBSyxDQUFDLElBQUksQ0FBQyxPQUFPLENBQUMsR0FBRyxDQUFDLEVBQUU7WUFDdkIsSUFBSSxVQUFVLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUFFO2dCQUN4QixNQUFNLE1BQU0sR0FBRyxtQkFBbUIsQ0FBQyxLQUFLLEVBQUUsTUFBTSxFQUFFLEdBQUcsQ0FBQyxDQUFDO2dCQUN2RCxJQUFJLEtBQUssQ0FBQyxNQUFNLEdBQUcsTUFBTSxHQUFHLENBQUM7b0JBQUUsa0JBQWtCLENBQUMsS0FBSyxFQUFFLEtBQUssRUFBRSxJQUFJLENBQUMsQ0FBQztnQkFFdEUsUUFBUSxLQUFSLFFBQVEsR0FBSyxDQUFDLGlCQUFpQixDQUFDLEtBQUssQ0FBQyxPQUFPLENBQUMsS0FBSyxFQUFFLEdBQUcsQ0FBQyxFQUFDO2FBQzNEO2lCQUNJO2dCQUNILE1BQU0sTUFBTSxHQUFHLGtCQUFrQixDQUFDLEtBQUssRUFBRSxLQUFLLEVBQUUsR0FBRyxDQUFDLENBQUM7Z0JBQ3JELElBQUksTUFBTSxDQUFDLE1BQU0sR0FBRyxNQUFNO29CQUN4QixtQkFBbUIsQ0FBQyxLQUFLLEVBQUUsTUFBTSxFQUFFLGFBQWEsQ0FBQyxNQUFNLEdBQUcsQ0FBQyxDQUFDLENBQUMsQ0FBQzthQUNqRTtRQUNILENBQUMsQ0FBQyxDQUFDO1FBRUgsT0FBTyxNQUFNLENBQUMsR0FBRyxDQUFDLENBQUMsS0FBSyxFQUFFLENBQUMsRUFBRSxFQUFFLENBQUMsQ0FBQyxFQUFFLEtBQUssRUFBRSxJQUFJLEVBQUUsS0FBSyxDQUFDLENBQUMsQ0FBQyxFQUFFLFFBQVEsRUFBRSxDQUFDLENBQUMsQ0FBQztJQUN6RSxDQUFDO0lBRUQsU0FBUyxtQkFBbUIsQ0FDMUIsS0FBbUIsRUFBRSxNQUFnQixFQUFFLFFBQWdCO1FBRXZELElBQUksTUFBTSxDQUFDLFFBQVEsQ0FBQyxRQUFRLENBQUM7WUFDM0IsTUFBTSxJQUFJLGVBQVksQ0FBQyxpQkFBaUIsRUFBRSxLQUFLLENBQUMsSUFBSSxDQUFDLENBQUM7UUFFeEQsT0FBTyxNQUFNLENBQUMsSUFBSSxDQUFDLFFBQVEsQ0FBQyxDQUFDO0lBQy9CLENBQUM7SUFFRCxTQUFTLGtCQUFrQixDQUN6QixLQUFtQixFQUFFLEtBQXdCLEVBQUUsT0FBc0I7UUFFckUsSUFBSSxPQUFPLElBQUksT0FBTyxDQUFDLE1BQU0sR0FBRyxnQ0FBb0I7WUFDbEQsTUFBTSxJQUFJLGVBQVksQ0FBQyxpQkFBaUIsRUFBRSxLQUFLLENBQUMsSUFBSSxDQUFDLENBQUM7UUFFeEQsT0FBTyxLQUFLLENBQUMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxDQUFDO0lBQzdCLENBQUM7SUFFRCxTQUFTLGlCQUFpQixDQUFDLEtBQW1CLEVBQUUsS0FBYTtRQUMzRCxNQUFNLEtBQUssR0FBRyxLQUFLLENBQUMsS0FBSyxDQUFDLGtCQUFrQixDQUFDLENBQUM7UUFDOUMsT0FBTyxLQUFLLElBQUksS0FBSyxDQUFDLENBQUMsQ0FBQyxLQUFLLENBQUMsTUFBTSxDQUFDLEtBQUssQ0FBQyxHQUFHLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQztJQUNuRSxDQUFDO0lBRUQsTUFBTSxlQUFlLEdBQUcsQ0FBQyxHQUFHLEVBQUUsR0FBRyxDQUFDLENBQUM7SUFFbkMsU0FBUyxrQkFBa0I7UUFDekIsT0FBTyxlQUFlLENBQUMsR0FBRyxDQUFDLEtBQUssQ0FBQyxFQUFFLENBQUMsQ0FDbEMsRUFBRSxLQUFLLEVBQUUsS0FBSyxFQUFFLElBQUksRUFBRSxJQUFJLEVBQUUsUUFBUSxFQUFFLEtBQUssRUFBRSxDQUM5QyxDQUFDLENBQUM7SUFDTCxDQUFDO0lBRUQsU0FBUyxtQkFBbUIsQ0FDMUIsS0FBbUIsRUFBRSxLQUFZO1FBRWpDLE1BQU0sT0FBTyxHQUFHLEtBQUssQ0FBQyxPQUFPLENBQUM7UUFDOUIsTUFBTSxPQUFPLEdBQUcsT0FBTyxDQUFDLE9BQU8sQ0FBQztRQUNoQyxJQUFJLE9BQU8sQ0FBQyxJQUFJLEtBQUssSUFBSTtZQUFFLE9BQU8sS0FBSyxDQUFDO1FBRXhDLE1BQU0sYUFBYSxHQUFHLE9BQU8sQ0FBQyxjQUFjLENBQUMsS0FBSyxDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQzFELE1BQU0saUJBQWlCLEdBQUcsdUJBQXVCLENBQUMsT0FBTyxDQUFDLENBQUM7UUFDM0QsSUFBSSxDQUFDLGFBQWEsSUFBSSxDQUFDLGlCQUFpQjtZQUFFLE9BQU8sS0FBSyxDQUFDO1FBRXZELHFCQUFxQixDQUFDLEtBQUssRUFBRSxLQUFLLEVBQUUsYUFBYSxDQUFDLENBQUM7UUFDbkQseUJBQXlCLENBQUMsS0FBSyxFQUFFLEtBQUssRUFBRSxhQUFhLEVBQUUsaUJBQWlCLENBQUMsQ0FBQztRQUUxRSxPQUFPLElBQUksQ0FBQztJQUNkLENBQUM7SUFFRCxNQUFNLGVBQWUsR0FBZ0M7UUFDbkQsZUFBZSxFQUFFLHNCQUFzQjtLQUN4QyxDQUFDO0lBQ0YsTUFBTSxvQkFBb0IsR0FBZ0M7UUFDeEQsaUJBQWlCO0tBQ2xCLENBQUM7SUFDRixNQUFNLG1CQUFtQixHQUFnQztRQUN2RCxxQkFBcUI7S0FDdEIsQ0FBQztJQUNGLE1BQU0sa0JBQWtCLEdBQWdDO1FBQ3RELGtCQUFrQjtLQUNuQixDQUFDO0lBQ0YsTUFBTSxzQkFBc0IsR0FBZ0M7UUFDMUQsY0FBYztLQUNmLENBQUM7SUFFRixTQUFTLHVCQUF1QixDQUM5QixPQUFnQjtRQUVoQixJQUFJLE9BQU8sQ0FBQyxPQUFPLENBQUMsSUFBSSxLQUFLLElBQUk7WUFBRSxPQUFPLElBQUksQ0FBQztRQUUvQyxJQUFJLE9BQU8sQ0FBQyxTQUFTO1lBQ25CLE9BQU8sSUFBSSx3QkFBVyxDQUFDLHlDQUE2QixDQUFDLENBQUM7O1lBRXRELE9BQU8sT0FBTyxDQUFDLE9BQU8sQ0FBQyxjQUFjLENBQUMsT0FBTyxDQUFDLE1BQU0sQ0FBQyxDQUFDO0lBQzFELENBQUM7SUFFRCxTQUFTLHFCQUFxQixDQUM1QixLQUFtQixFQUFFLEtBQVksRUFBRSxXQUFrQztRQUVyRSxNQUFNLGtCQUFrQixHQUFHLHVCQUF1QixDQUFDLEtBQUssQ0FBQyxDQUFDO1FBQzFELE1BQU0sa0JBQWtCLEdBQUcsV0FBVyxDQUFDLE9BQU8sQ0FBQyxrQkFBa0IsQ0FBQyxDQUFDO1FBQ25FLElBQUksa0JBQWtCLENBQUMsTUFBTTtZQUMzQixNQUFNLElBQUksZUFBWSxDQUNwQixpQkFBaUIsRUFBRSxLQUFLLENBQUMsSUFBSSxFQUFFLGtCQUFrQixDQUNsRCxDQUFDO0lBQ04sQ0FBQztJQUVELFNBQVMsdUJBQXVCLENBQUMsS0FBWTtRQUMzQyxNQUFNLFdBQVcsR0FBRyxlQUFlLENBQUMsS0FBSyxFQUFFLENBQUM7UUFFNUMsSUFBSSxLQUFLLENBQUMsU0FBUztZQUFFLFdBQVcsQ0FBQyxJQUFJLENBQUMsR0FBRyxvQkFBb0IsQ0FBQyxDQUFDO1FBQy9ELElBQUksS0FBSyxDQUFDLE9BQU8sQ0FBQyxJQUFJLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQyxNQUFNLENBQUMsUUFBUSxDQUFDO1lBQy9DLFdBQVcsQ0FBQyxJQUFJLENBQUMsR0FBRyxtQkFBbUIsQ0FBQyxDQUFDO1FBQzNDLElBQUksS0FBSyxDQUFDLFFBQVE7WUFBRSxXQUFXLENBQUMsSUFBSSxDQUFDLEdBQUcsc0JBQXNCLENBQUMsQ0FBQztRQUVoRSxPQUFPLFdBQVcsQ0FBQztJQUNyQixDQUFDO0lBRUQsU0FBUyx5QkFBeUIsQ0FDaEMsS0FBbUIsRUFBRSxLQUFZLEVBQ2pDLGFBQW9DLEVBQ3BDLGlCQUF3QztRQUV4QyxNQUFNLGtCQUFrQixHQUNwQiw0QkFBNEIsQ0FBQyxLQUFLLEVBQUUsYUFBYSxDQUFDLENBQUM7UUFDdkQsTUFBTSxrQkFBa0IsR0FBRyxpQkFBaUIsQ0FBQyxPQUFPLENBQUMsa0JBQWtCLENBQUMsQ0FBQztRQUN6RSxJQUFJLGtCQUFrQixDQUFDLE1BQU07WUFDM0IsTUFBTSxJQUFJLGVBQVksQ0FDcEIscUJBQXFCLEVBQUUsS0FBSyxDQUFDLElBQUksRUFBRSxrQkFBa0IsQ0FDdEQsQ0FBQztJQUNOLENBQUM7SUFFRCxTQUFTLDRCQUE0QixDQUNuQyxLQUFZLEVBQUUsV0FBa0M7UUFFaEQsT0FBTyxLQUFLLENBQUMsUUFBUSxDQUFDLE1BQU0sSUFBSSxXQUFXLENBQUMsR0FBRyxDQUFDLGtCQUFrQixDQUFDO1lBQ2pFLENBQUMsQ0FBQyxrQkFBa0IsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO0lBQzlCLENBQUM7SUFFRCxTQUFTLGNBQWMsQ0FBQyxLQUFtQixFQUFFLEtBQVk7UUFDdkQsT0FBTyxLQUFLLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQyxJQUFJLENBQy9CLEtBQUssQ0FBQyxRQUFRLENBQUMsSUFBSSxDQUFDLEdBQUcsQ0FBQyxFQUN4QjtZQUNFLEtBQUssRUFBRSxnQkFBTyxDQUFDLEtBQUssQ0FBQyxJQUFJLENBQUMsQ0FBQyxRQUFRLENBQUMsSUFBSSxDQUFDLEtBQUssQ0FBQyxTQUFTLENBQUM7WUFDekQsS0FBSyxFQUFFLEtBQUssQ0FBQyxRQUFRLENBQUMsQ0FBQyxDQUFDLENBQUMsS0FBSyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUMsQ0FBQyxFQUFFO1NBQzlDLENBQ0YsQ0FBQztJQUNKLENBQUM7SUFFRCxLQUFLLFVBQVUsZUFBZSxDQUM1QixLQUFtQixFQUFFLEtBQVksRUFBRSxRQUFpQjtRQUVwRCxJQUFJO1lBQ0YsTUFBTSxPQUFPLENBQUMsR0FBRyxDQUNmLEtBQUssQ0FBQyxPQUFPLENBQUMsR0FBRyxDQUFDLE1BQU0sQ0FBQyxFQUFFLENBQUMsUUFBUSxDQUFDLEtBQUssQ0FBQyxNQUFNLENBQUMsS0FBSyxDQUFDLENBQUMsQ0FDMUQsQ0FBQztTQUNIO1FBQ0QsT0FBTyxTQUFrQixFQUFFO1lBQ3pCLElBQUksU0FBUyxZQUFZLDRCQUFlO2dCQUN0QyxJQUFJLFNBQVMsQ0FBQyxVQUFVLEtBQUssR0FBRztvQkFDOUIsTUFBTSxJQUFJLGVBQVksQ0FBQyxlQUFlLEVBQUUsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDO1NBQ3pEO0lBQ0gsQ0FBQztJQUVELFNBQVMsV0FBVyxDQUNsQixLQUFtQixFQUFFLEtBQVksRUFBRSxRQUFpQjtRQUVwRCxNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsT0FBTyxDQUFDO1FBQzlCLE1BQU0sU0FBUyxHQUFhLE9BQU8sQ0FBQyxJQUFJLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQyxNQUFNLENBQUMsSUFBSSxLQUFLLElBQUksQ0FBQztZQUN0RSxDQUFDLENBQUMsT0FBTyxDQUFDLEdBQUcsQ0FBQyxNQUFNLENBQUMsRUFBRSxDQUFDLE1BQU0sQ0FBQyxLQUFLLENBQUMsQ0FBQyxDQUFDLENBQUMsRUFBRSxDQUFDO1FBRTdDLE9BQU8sUUFBUSxDQUFDLElBQUksQ0FDbEIsS0FBSyxDQUFDLFFBQVEsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQ3hCO1lBQ0UsS0FBSyxFQUFFLGdCQUFPLENBQUMsS0FBSyxDQUFDLElBQUksQ0FBQyxDQUFDLFNBQVMsQ0FBQyxJQUFJLENBQ3ZDLEtBQUssQ0FBQyxTQUFTLEVBQ2YsS0FBSyxDQUFDLE1BQU0sQ0FBQyxPQUFPLEVBQ3BCLEtBQUssQ0FBQyxNQUFNLENBQUMsSUFBSSxFQUNqQixLQUFLLENBQUMsUUFBUSxJQUFJLEVBQUUsRUFDcEIsU0FBUyxFQUNULE9BQU8sQ0FBQyxHQUFHLENBQUMsTUFBTSxDQUFDLEVBQUUsQ0FBQyxNQUFNLENBQUMsSUFBSSxJQUFJLEVBQUUsQ0FBQyxFQUN4QyxLQUFLLENBQUMsUUFBUSxDQUFDLENBQUMsQ0FBQyxlQUFRLENBQUMsS0FBSyxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUMsQ0FBQyxJQUFJLEVBQ2hELFFBQVEsQ0FBQyxPQUFPLENBQUMsRUFBRSxFQUNuQixRQUFRLENBQUMsRUFBRSxDQUNaO1NBQ0YsQ0FDRixDQUFDO0lBQ0osQ0FBQztJQUVELFNBQVMsWUFBWSxDQUNuQixLQUFtQixFQUFFLEtBQW1CO1FBRXhDLE1BQU0sT0FBTyxHQUFHLEVBQUUsS0FBSyxFQUFFLEtBQUssQ0FBQyxLQUFLLEVBQUUsQ0FBQztRQUN2QyxNQUFNLE9BQU8sR0FBRyxLQUFLLENBQUMsT0FBTyxDQUFDLE9BQU8sQ0FBQztRQUN0QyxNQUFNLFFBQVEsR0FBRyxLQUFLLENBQUMsUUFBUSxDQUFDO1FBRWhDLE9BQU8sUUFBUSxDQUFDLENBQUMsQ0FBQyxRQUFRLENBQUMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxDQUFDLENBQUMsQ0FBQyxPQUFPLENBQUMsSUFBSSxDQUFDLE9BQU8sQ0FBQyxDQUFDO0lBQ25FLENBQUM7QUFDSCxDQUFDLEVBelVnQixJQUFJLEdBQUosWUFBSSxLQUFKLFlBQUksUUF5VXBCIn0=

--- a/src/bot/responders/poll.ts
+++ b/src/bot/responders/poll.ts
@@ -31,6 +31,193 @@ export namespace Poll {
     choices  : Choice[],
   }
 
+  export function initialize(): void {
+    Allocater.entryResponder(
+      `${COMMAND_PREFIX}poll`,   chunk => respond(chunk, false)
+    );
+    Allocater.entryResponder(
+      `${COMMAND_PREFIX}expoll`, chunk => respond(chunk, true)
+    );
+  }
+
+  async function respond(
+    chunk: RequestChunk, exclusive: boolean
+  ): Promise<Message | null> {
+    if (chunk.response) clearSelectors(chunk.response);
+    if (!chunk.args.length) return respondHelp(chunk);
+
+    try {
+      const query = parse(chunk, exclusive);
+      if (!validatePermissions(chunk, query)) return null;
+
+      chunk.response ??= await respondLoading(chunk, query);
+      await attachSelectors(chunk, query, chunk.response);
+      return respondPoll(chunk, query, chunk.response);
+    }
+    catch (error: unknown) {
+      if (error instanceof CommandError) return respondError(chunk, error);
+      throw error;
+    }
+  }
+
+  function clearSelectors(response: Message): void {
+    response.reactions.removeAll()
+      .catch(() => undefined);
+  }
+
+  function respondHelp(chunk: RequestChunk): Promise<Message> {
+    const options = { content: '', embed: Help.getEmbed(chunk.lang) };
+    const channel = chunk.request.channel;
+    const response = chunk.response;
+
+    return response ? response.edit(options) : channel.send(options);
+  }
+
+  function parse(chunk: RequestChunk, exclusive: boolean): Query {
+    const query = {
+      exclusive: exclusive,
+      author   : parseAuthor(chunk),
+      imageURL : parseAttachedImage(chunk),
+      mentions : parseMentions(chunk),
+      question : parseQuestion(chunk),
+      choices  : parseChoices(chunk),
+    };
+
+    if (query.mentions.length && query.question === null)
+      throw new CommandError('ungivenQuestion', chunk.lang);
+
+    return query;
+  }
+
+  function parseAuthor(chunk: RequestChunk): Author {
+    const user = chunk.request.author;
+    const member = chunk.request.member;
+
+    return {
+      iconURL: user.displayAvatarURL(),
+      name: member?.displayName ?? user.username,
+    };
+  }
+
+  const imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
+
+  function parseAttachedImage(chunk: RequestChunk): string | null {
+    return chunk.request.attachments.find(
+      attachment => imageExtensions.includes(extname(attachment.url))
+    )?.url ?? null;
+  }
+
+  function parseMentions(chunk: RequestChunk): string[] {
+    const mentions: string[] = [];
+
+    for (const arg of chunk.args) {
+      const matchMention = arg.match(/^(@everyone|@here|<@&\d+>)$/);
+      const matchEvery   = arg.match(/^(?!\\)(everyone|here)$/);
+      const matchNumber  = arg.match(/^(?!\\)(\d+)$/);
+      if (!matchMention && !matchEvery && !matchNumber) break;
+
+      if (matchMention) mentions.push(matchMention[1]);
+      if (matchEvery)   mentions.push(`@${matchEvery[1]}`);
+      if (matchNumber)  mentions.push(`<@&${matchNumber[1]}>`);
+    }
+
+    mentions.forEach(() => chunk.args.shift());
+
+    return mentions;
+  }
+
+  function parseQuestion(chunk: RequestChunk): string | null {
+    return chunk.args.shift() ?? null;
+  }
+
+  function parseChoices(chunk: RequestChunk): Choice[] {
+    const choices
+      = chunk.args.length ? generateChoices(chunk) : generateTwoChoices();
+
+    if (choices.length > COMMAND_MAX_CHOICES)
+      throw new CommandError('tooManyOptions', chunk.lang);
+
+    return choices;
+  }
+
+  const defaultEmojis = [
+    '🇦', '🇧', '🇨', '🇩', '🇪', '🇫', '🇬', '🇭', '🇮', '🇯', '🇰', '🇱', '🇲',
+    '🇳', '🇴', '🇵', '🇶', '🇷', '🇸', '🇹', '🇺', '🇻', '🇼', '🇽', '🇾', '🇿',
+  ];
+  const twemojiRegex
+    = require('twemoji-parser/dist/lib/regex.js').default as RegExp;
+  const emojiRegex
+    = new RegExp(`^(${twemojiRegex.toString().slice(1, -2)}|<a?:.+?:\\d+>)$`);
+
+  function generateChoices(chunk: RequestChunk): Choice[] {
+    const emojis: string[] = [], texts: (string | null)[] = [];
+    let external = false;
+
+    chunk.args.forEach(arg => {
+      if (emojiRegex.test(arg)) {
+        const length = safePushChoiceEmoji(chunk, emojis, arg);
+        if (texts.length < length - 1) safePushChoiceText(chunk, texts, null);
+
+        external ||= !isLocalGuildEmoji(chunk.request.guild, arg);
+      }
+      else {
+        const length = safePushChoiceText(chunk, texts, arg);
+        if (emojis.length < length)
+          safePushChoiceEmoji(chunk, emojis, defaultEmojis[length - 1]);
+      }
+    });
+
+    return emojis.map((emoji, i) => ({ emoji, text: texts[i], external }));
+  }
+
+  function safePushChoiceEmoji(
+    chunk: RequestChunk, emojis: string[], newEmoji: string
+  ): number {
+    if (emojis.includes(newEmoji))
+      throw new CommandError('duplicateEmojis', chunk.lang);
+
+    return emojis.push(newEmoji);
+  }
+
+  function safePushChoiceText(
+    chunk: RequestChunk, texts: (string | null)[], newtext: string | null
+  ): number {
+    if (newtext && newtext.length > COMMAND_QUESTION_MAX)
+      throw new CommandError('tooLongQuestion', chunk.lang);
+
+    return texts.push(newtext);
+  }
+
+  function isLocalGuildEmoji(guild: Guild | null, emoji: string): boolean {
+    const match = emoji.match(/^<a?:.+?:(\d+)>$/);
+    return guild && match ? guild.emojis.cache.has(match[1]) : false;
+  }
+
+  const twoChoiceEmojis = ['⭕', '❌'];
+
+  function generateTwoChoices(): Choice[] {
+    return twoChoiceEmojis.map(emoji => (
+      { emoji: emoji, text: null, external: false }
+    ));
+  }
+
+  function validatePermissions(
+    chunk: RequestChunk, query: Query
+  ): boolean {
+    const request = chunk.request;
+    const channel = request.channel;
+    if (channel.type === 'dm') return false;
+
+    const myPermissions = channel.permissionsFor(chunk.botID);
+    const authorPermissions = getAuthorPermissionsFor(request);
+    if (!myPermissions || !authorPermissions) return false;
+
+    validateMyPermissions(chunk, query, myPermissions);
+    validateAuthorPermissions(chunk, query, myPermissions, authorPermissions);
+
+    return true;
+  }
+
   const pollPermissions: readonly PermissionString[] = [
     'ADD_REACTIONS', 'READ_MESSAGE_HISTORY'
   ];
@@ -47,11 +234,26 @@ export namespace Poll {
     'ATTACH_FILES'
   ];
 
-  function sumRequireAuthoerPermissions(
-    query: Query, permissions: Readonly<Permissions>
-  ): readonly PermissionString[] {
-    return query.mentions.length && permissions.has(mentionPermissions)
-      ? mentionPermissions : [];
+  function getAuthorPermissionsFor(
+    request: Message
+  ): Readonly<Permissions> | null {
+    if (request.channel.type === 'dm') return null;
+     
+    if (request.webhookID)
+      return new Permissions(POSTULATE_WEBHOOK_PERMISSIONS);
+    else
+      return request.channel.permissionsFor(request.author);
+  }
+
+  function validateMyPermissions(
+    chunk: RequestChunk, query: Query, permissions: Readonly<Permissions>
+  ): void {
+    const requirePermissions = sumRequireMyPermissions(query);
+    const missingPermissions = permissions.missing(requirePermissions);
+    if (missingPermissions.length)
+      throw new CommandError(
+        'lackPermissions', chunk.lang, missingPermissions
+      );
   }
 
   function sumRequireMyPermissions(query: Query): PermissionString[] {
@@ -79,181 +281,36 @@ export namespace Poll {
       );
   }
 
-  function validateMyPermissions(
-    chunk: RequestChunk, query: Query, permissions: Readonly<Permissions>
-  ): void {
-    const requirePermissions = sumRequireMyPermissions(query);
-    const missingPermissions = permissions.missing(requirePermissions);
-    if (missingPermissions.length)
-      throw new CommandError(
-        'lackPermissions', chunk.lang, missingPermissions
+  function sumRequireAuthoerPermissions(
+    query: Query, permissions: Readonly<Permissions>
+  ): readonly PermissionString[] {
+    return query.mentions.length && permissions.has(mentionPermissions)
+      ? mentionPermissions : [];
+  }
+
+  function respondLoading(chunk: RequestChunk, query: Query): Promise<Message> {
+    return chunk.request.channel.send(
+      query.mentions.join(' '),
+      {
+        embed: Locales[chunk.lang].loadings.poll(query.exclusive),
+        files: query.imageURL ? [query.imageURL] : [],
+      }
+    );
+  }
+
+  async function attachSelectors(
+    chunk: RequestChunk, query: Query, response: Message
+  ): Promise<void> {
+    try {
+      await Promise.all(
+        query.choices.map(choice => response.react(choice.emoji))
       );
-  }
-
-  function getAuthorPermissionsFor(
-    request: Message
-  ): Readonly<Permissions> | null {
-    if (request.channel.type === 'dm') return null;
-     
-    if (request.webhookID)
-      return new Permissions(POSTULATE_WEBHOOK_PERMISSIONS);
-    else
-      return request.channel.permissionsFor(request.author);
-  }
-
-  function validatePermissions(
-    chunk: RequestChunk, query: Query
-  ): boolean {
-    const request = chunk.request;
-    const channel = request.channel;
-    if (channel.type === 'dm') return false;
-
-    const myPermissions = channel.permissionsFor(chunk.botID);
-    const authorPermissions = getAuthorPermissionsFor(request);
-    if (!myPermissions || !authorPermissions) return false;
-
-    validateMyPermissions(chunk, query, myPermissions);
-    validateAuthorPermissions(chunk, query, myPermissions, authorPermissions);
-
-    return true;
-  }
-
-  function isLocalGuildEmoji(guild: Guild | null, emoji: string): boolean {
-    const match = emoji.match(/^<a?:.+?:(\d+)>$/);
-    return guild && match ? guild.emojis.cache.has(match[1]) : false;
-  }
-
-  const defaultEmojis = [
-    '🇦', '🇧', '🇨', '🇩', '🇪', '🇫', '🇬', '🇭', '🇮', '🇯', '🇰', '🇱', '🇲',
-    '🇳', '🇴', '🇵', '🇶', '🇷', '🇸', '🇹', '🇺', '🇻', '🇼', '🇽', '🇾', '🇿',
-  ];
-  const twemojiRegex
-    = require('twemoji-parser/dist/lib/regex.js').default as RegExp;
-  const emojiRegex
-    = new RegExp(`^(${twemojiRegex.toString().slice(1, -2)}|<a?:.+?:\\d+>)$`);
-
-  function safePushChoiceEmoji(
-    chunk: RequestChunk, emojis: string[], newEmoji: string
-  ): number {
-    if (emojis.includes(newEmoji))
-      throw new CommandError('duplicateEmojis', chunk.lang);
-
-    return emojis.push(newEmoji);
-  }
-
-  function safePushChoiceText(
-    chunk: RequestChunk, texts: (string | null)[], newtext: string | null
-  ): number {
-    if (newtext && newtext.length > COMMAND_QUESTION_MAX)
-      throw new CommandError('tooLongQuestion', chunk.lang);
-
-    return texts.push(newtext);
-  }
-
-  function generateChoices(chunk: RequestChunk): Choice[] {
-    const emojis: string[] = [], texts: (string | null)[] = [];
-    let external = false;
-
-    chunk.args.forEach(arg => {
-      if (emojiRegex.test(arg)) {
-        const length = safePushChoiceEmoji(chunk, emojis, arg);
-        if (texts.length < length - 1) safePushChoiceText(chunk, texts, null);
-
-        external ||= !isLocalGuildEmoji(chunk.request.guild, arg);
-      }
-      else {
-        const length = safePushChoiceText(chunk, texts, arg);
-        if (emojis.length < length)
-          safePushChoiceEmoji(chunk, emojis, defaultEmojis[length - 1]);
-      }
-    });
-
-    return emojis.map((emoji, i) => ({ emoji, text: texts[i], external }));
-  }
-
-  const twoChoiceEmojis = ['⭕', '❌'];
-
-  function generateTwoChoices(): Choice[] {
-    return twoChoiceEmojis.map(emoji => (
-      { emoji: emoji, text: null, external: false }
-    ));
-  }
-
-  function parseChoices(chunk: RequestChunk): Choice[] {
-    const choices
-      = chunk.args.length ? generateChoices(chunk) : generateTwoChoices();
-
-    if (choices.length > COMMAND_MAX_CHOICES)
-      throw new CommandError('tooManyOptions', chunk.lang);
-
-    return choices;
-  }
-
-  function parseQuestion(chunk: RequestChunk): string | null {
-    return chunk.args.shift() ?? null;
-  }
-
-  function parseMentions(chunk: RequestChunk): string[] {
-    const mentions: string[] = [];
-
-    for (const arg of chunk.args) {
-      const matchMention = arg.match(/^(@everyone|@here|<@&\d+>)$/);
-      const matchEvery   = arg.match(/^(?!\\)(everyone|here)$/);
-      const matchNumber  = arg.match(/^(?!\\)(\d+)$/);
-      if (!matchMention && !matchEvery && !matchNumber) break;
-
-      if (matchMention) mentions.push(matchMention[1]);
-      if (matchEvery)   mentions.push(`@${matchEvery[1]}`);
-      if (matchNumber)  mentions.push(`<@&${matchNumber[1]}>`);
     }
-
-    mentions.forEach(() => chunk.args.shift());
-
-    return mentions;
-  }
-
-  const imageExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
-
-  function parseAttachedImage(chunk: RequestChunk): string | null {
-    return chunk.request.attachments.find(
-      attachment => imageExtensions.includes(extname(attachment.url))
-    )?.url ?? null;
-  }
-
-  function parseAuthor(chunk: RequestChunk): Author {
-    const user = chunk.request.author;
-    const member = chunk.request.member;
-
-    return {
-      iconURL: user.displayAvatarURL(),
-      name: member?.displayName ?? user.username,
-    };
-  }
-
-  function parse(chunk: RequestChunk, exclusive: boolean): Query {
-    const query = {
-      exclusive: exclusive,
-      author   : parseAuthor(chunk),
-      imageURL : parseAttachedImage(chunk),
-      mentions : parseMentions(chunk),
-      question : parseQuestion(chunk),
-      choices  : parseChoices(chunk),
-    };
-
-    if (query.mentions.length && query.question === null)
-      throw new CommandError('ungivenQuestion', chunk.lang);
-
-    return query;
-  }
-
-  function respondError(
-    chunk: RequestChunk, error: CommandError
-  ): Promise<Message> {
-    const options = { embed: error.embed };
-    const channel = chunk.request.channel;
-    const response = chunk.response;
-
-    return response ? response.edit(options) : channel.send(options);
+    catch (exception: unknown) {
+      if (exception instanceof DiscordAPIError)
+        if (exception.httpStatus === 400)
+          throw new CommandError('unusableEmoji', chunk.lang);
+    }
   }
 
   function respondPoll(
@@ -281,70 +338,13 @@ export namespace Poll {
     );
   }
 
-  async function attachSelectors(
-    chunk: RequestChunk, query: Query, response: Message
-  ): Promise<void> {
-    try {
-      await Promise.all(
-        query.choices.map(choice => response.react(choice.emoji))
-      );
-    }
-    catch (exception: unknown) {
-      if (exception instanceof DiscordAPIError)
-        if (exception.httpStatus === 400)
-          throw new CommandError('unusableEmoji', chunk.lang);
-    }
-  }
-
-  function respondLoading(chunk: RequestChunk, query: Query): Promise<Message> {
-    return chunk.request.channel.send(
-      query.mentions.join(' '),
-      {
-        embed: Locales[chunk.lang].loadings.poll(query.exclusive),
-        files: query.imageURL ? [query.imageURL] : [],
-      }
-    );
-  }
-
-  function respondHelp(chunk: RequestChunk): Promise<Message> {
-    const options = { content: '', embed: Help.getEmbed(chunk.lang) };
+  function respondError(
+    chunk: RequestChunk, error: CommandError
+  ): Promise<Message> {
+    const options = { embed: error.embed };
     const channel = chunk.request.channel;
     const response = chunk.response;
 
     return response ? response.edit(options) : channel.send(options);
-  }
-
-  function clearSelectors(response: Message): void {
-    response.reactions.removeAll()
-      .catch(() => undefined);
-  }
-
-  async function respond(
-    chunk: RequestChunk, exclusive: boolean
-  ): Promise<Message | null> {
-    if (chunk.response) clearSelectors(chunk.response);
-    if (!chunk.args.length) return respondHelp(chunk);
-
-    try {
-      const query = parse(chunk, exclusive);
-      if (!validatePermissions(chunk, query)) return null;
-
-      chunk.response ??= await respondLoading(chunk, query);
-      await attachSelectors(chunk, query, chunk.response);
-      return respondPoll(chunk, query, chunk.response);
-    }
-    catch (error: unknown) {
-      if (error instanceof CommandError) return respondError(chunk, error);
-      throw error;
-    }
-  }
-  
-  export function initialize(): void {
-    Allocater.entryResponder(
-      `${COMMAND_PREFIX}poll`,   chunk => respond(chunk, false)
-    );
-    Allocater.entryResponder(
-      `${COMMAND_PREFIX}expoll`, chunk => respond(chunk, true)
-    );
   }
 }


### PR DESCRIPTION
現在、BOTに@everyoneの権限がある状態で、コマンド送信者側に@everyone権限がない場合、送信者が権限を越えた操作を防止するため、アンケートに代えて権限が足りない旨を伝えるエラーメッセージを送信している。
しかしDiscordでは`allowed_mentions`という通知を送信するか否かを指定できるオプションがあるため、これを使用してエラーメッセージを表示するのではなく、メンションの通知を無効化するほうが、より柔軟にBOTを使用して頂けるのではないかと思い、このオプションを追加する方法での実装を検討したい。
なお、現在アンケート集計のメンションが、アンケートのメンションをそのまま引き継ぐ設定であるため、どのユーザーが集計コマンドを使用してもメンションの通知が送られてしまう。
この点も本PRで改善したい。

なお、初回のコミットでは、`poll.ts`の記述が以前から他のファイルとはフォーマットが違っていたため、修正をおこなった。